### PR TITLE
Fix broken requirement (dataclasses)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ colorama==0.4.4
 cookiecutter==1.7.3
 cryptography==3.4.7
 cycler==0.10.0
-dataclasses==0.8
+dataclasses
 decorator==4.4.2
 Flask==2.0.2
 funcparserlib==0.3.5


### PR DESCRIPTION
Installando i requirements della repo si verifica il seguente errore. Non ho approfondito il motivo, ma per risolverlo è bastato rimuovere il numero di versione del pacchetto. Forse puoi anche rimuovere il requisito, siccome dataclasses è incluso da Python 3.7 in poi, che hanno tutti

https://github.com/ericvsmith/dataclasses/issues/165